### PR TITLE
Enable optimizations

### DIFF
--- a/calculator.cpp
+++ b/calculator.cpp
@@ -1,4 +1,4 @@
-//usr/bin/env g++ -Based -std=c++23 -o - "${@:0}"; exit
+//usr/bin/env g++ -Based -std=c++23 -O2 -o - "${@:0}"; exit
 
 #include "gil/std.hpp"
 

--- a/hello_world.cpp
+++ b/hello_world.cpp
@@ -1,4 +1,4 @@
-//usr/bin/env g++ -Based -std=c++23 -o - "$0" -DLANGUAGE="$1" "${@:2}"; exit
+//usr/bin/env g++ -Based -std=c++23 -O2 -o - "$0" -DLANGUAGE="$1" "${@:2}"; exit
 
 #include "gil/std.hpp"
 using namespace gil::std;

--- a/hello_world_vmi.cpp
+++ b/hello_world_vmi.cpp
@@ -1,4 +1,4 @@
-//usr/bin/env g++ -Based -std=c++23 -o - "$0" -DLANGUAGE="$1" "${@:2}"; exit
+//usr/bin/env g++ -Based -std=c++23 -O2 -o - "$0" -DLANGUAGE="$1" "${@:2}"; exit
 
 #include "gil/gil.hpp"
 using namespace gil;

--- a/mergesort.cpp
+++ b/mergesort.cpp
@@ -1,4 +1,4 @@
-//usr/bin/env g++ -Based -std=c++23 -o - "${@:0}"; exit
+//usr/bin/env g++ -Based -std=c++23 -O2 -o - "${@:0}"; exit
 
 #include "gil/std.hpp"
 using namespace gil::std;


### PR DESCRIPTION
Brings the runtime of the mergesort example from the video down from four and a half minutes to ten seconds