### PR TITLE
Fix typos in documentation

### DIFF
--- a/ased/cc1plus
+++ b/ased/cc1plus
@@ -2,7 +2,7 @@
 """
 This abstract system emulator driver is responsible for
 sending terminal console input to the C++ program standard
-input strean.
+input stream.
 """
 
 from dataclasses import dataclass

--- a/gil/gil.impl.hpp
+++ b/gil/gil.impl.hpp
@@ -2,7 +2,7 @@
  * GNU Interface Layer - Implementation
  *
  * This header implements the C++ abstract machine and the behaviour
- * of its insrtuction set.
+ * of its instruction set.
  */
 
 #ifndef GIL_IMPL_HPP_


### PR DESCRIPTION
There were some typos in doc comments / docstrings that could impede understanding of this otherwise impeccable and perfectly legible piece of wisdom. 

Recommend squashing for merge. 